### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `releaseBranch` config block to `enonic-gradle.yml` listing both `master` and `2.x` so the new maintenance branch is recognized as a release branch.

## Context

Companion to the XP 8 upgrade landing on `master`. The `2.x` branch is the XP 7 maintenance line and is preserved at the pre-upgrade state (`xpVersion=7.0.0`, `version=2.0.2-SNAPSHOT`); only the workflow changes here, mirroring the app-booster `1.x` pattern.

## Test plan

- [ ] CI on `chore/2.x-add-release-branch` is green