### PR TITLE
Upgrade to XP 8

### DIFF
--- a/.github/workflows/enonic-docgen.yml
+++ b/.github/workflows/enonic-docgen.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "master"
+      - "2.x"
     paths:
       - 'docs/**'
   workflow_dispatch:

--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'maven-publish'
-    id 'com.enonic.xp.base' version '3.6.2'
+    id 'com.enonic.xp.base'
     id 'com.enonic.defaults' version '2.1.6'
 }
 
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly "com.enonic.xp:script-api:${xpVersion}"
+    compileOnly xplibs.api.script
     implementation 'com.github.kenglxn.QRGen:javase:3.0.1'
 }
 

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,0 +1,6 @@
+{
+  "versions": [
+    { "label": "stable", "checkout": "2.x", "latest": true },
+    { "label": "next", "checkout": "master" }
+  ]
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,5 @@
 #
 group=com.enonic.lib
 projectName=lib-qrcode
-xpVersion=7.0.0
-version=2.0.2-SNAPSHOT
+xpVersion=8.0.0-B4
+version=3.0.0-SNAPSHOT

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,5 @@
+plugins {
+    id 'com.enonic.xp.settings' version '4.0.0-B1'
+}
+
 rootProject.name = projectName


### PR DESCRIPTION
## Summary

- Bump `xpVersion` to `8.0.0-B4` and project `version` to `3.0.0-SNAPSHOT`.
- Adopt `com.enonic.xp.settings` plugin `4.0.0-B1`; drop the explicit `com.enonic.xp.base` version pin (settings plugin now supplies it) and migrate `script-api` to the `xplibs.api.script` catalog alias.
- Bump Gradle wrapper to `9.4.1`.
- Add the `2.x` maintenance branch to the `build-and-publish` `releaseBranch` list and to the `enonic-docgen` push filter, and create `docs/versions.json` mapping `stable` → `2.x` and `next` → `master`.

## Notes

- This is a library — no XML descriptors, so `xp8migrator` was skipped per the `xp-app-upgrader` skill's library subset.
- No JUnit changes: this lib has no tests.
- The XP 7 maintenance line lives on `2.x` (created from the previous `master` HEAD `761a329`); CI on `2.x` is wired in via #51.

## Verification

- `./gradlew clean build` is green on Java 25 with the 9.4.1 wrapper.

## Test plan

- [ ] CI on `chore/upgrade-to-xp8` is green.