### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ repositories {
 
 dependencies {
     compileOnly xplibs.api.script
-    implementation 'com.github.kenglxn.QRGen:javase:3.0.1'
+    implementation libs.qrgen.javase
 }
 
 artifacts {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,5 @@
+[versions]
+qrgen = "3.0.1"
+
+[libraries]
+qrgen-javase = { module = "com.github.kenglxn.QRGen:javase", version.ref = "qrgen" }


### PR DESCRIPTION
## Summary

Migrate the one inline-versioned dependency (`com.github.kenglxn.QRGen:javase:3.0.1`) into `gradle/libs.versions.toml`, so this repo follows the same pattern as neighbouring app- / lib- projects in the tree. Pin-for-pin: no version bumps, dependency tree identical (`./gradlew dependencies --configuration runtimeClasspath` diff is empty modulo wall-clock).

## Conventions adopted

- Alphabetical sort of `[versions]` / `[libraries]`.
- Lowercase, hyphen-separated keys (`qrgen`, `qrgen-javase`).
- `xpVersion` left in `gradle.properties` — toolchain expects it there.
- `xplibs.*` accessors untouched — those come from the XP gradle plugin.

## Catalog

\`\`\`toml
[versions]
qrgen = "3.0.1"

[libraries]
qrgen-javase = { module = "com.github.kenglxn.QRGen:javase", version.ref = "qrgen" }
\`\`\`

## Test plan

- [x] \`./gradlew build --refresh-dependencies\` — BUILD SUCCESSFUL
- [x] \`./gradlew dependencies --configuration runtimeClasspath\` diff against pre-migration HEAD — identical