### PR TITLE
Add @enonic-types/lib-qrcode types package #59

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -2,6 +2,10 @@ name: Gradle Build
 
 on: [ push ]
 
+permissions:
+  id-token: write  # Required for npm OIDC / trusted publishing
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,6 +17,7 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          npmPublish: true
           releaseBranch: |
             master
             2.x

--- a/build.gradle
+++ b/build.gradle
@@ -20,3 +20,15 @@ dependencies {
 artifacts {
     archives jar
 }
+
+// Assemble the @enonic-types/lib-qrcode npm package (published on release by the CI npmPublish step).
+tasks.register('assembleTypes', Copy) {
+    from 'types'
+    into layout.buildDirectory.dir('types')
+    filesMatching('package.json') {
+        filter { line ->
+            line.replaceAll(/"version":\s*"[^"]*"/, "\"version\": \"${project.version}\"")
+        }
+    }
+}
+jar.dependsOn assembleTypes

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,27 @@
+import type { ByteSource } from "@enonic-types/core";
+
+declare module "/lib/qrcode" {
+    interface GenerateQrCodeParams {
+        /**
+         * The text or URL to be encoded in the QR code.
+         */
+        text: string;
+
+        /**
+         * The width and height of the square image generated, in pixels.
+         *
+         * @default 250
+         */
+        size?: number;
+    }
+
+    /**
+     * Generates a PNG image with a QR Code that encodes the specified text.
+     *
+     * @param params Options controlling the generated QR code.
+     * @returns Stream containing the generated PNG image.
+     */
+    export function generateQrCode(params: GenerateQrCodeParams): ByteSource;
+}
+
+export {};

--- a/types/package.json
+++ b/types/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@enonic-types/lib-qrcode",
+  "version": "0.0.0",
+  "description": "Type definitions for the Enonic XP QR Code library",
+  "types": "index.d.ts",
+  "files": [
+    "*"
+  ],
+  "keywords": [
+    "enonic",
+    "enonic-xp",
+    "lib-qrcode",
+    "qrcode",
+    "types",
+    "typescript"
+  ],
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/enonic/lib-qrcode#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/enonic/lib-qrcode.git"
+  },
+  "bugs": {
+    "url": "https://github.com/enonic/lib-qrcode/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@enonic-types/core": "^8.0.0"
+  }
+}


### PR DESCRIPTION
Adds a published TypeScript types package for **lib-qrcode** so consumers get typed access to `/lib/qrcode` instead of hand-authoring local declarations.

## What

- `types/index.d.ts` — ambient `declare module "/lib/qrcode"` covering the sole export:
  - `generateQrCode({ text: string; size?: number }): ByteSource` (size defaults to 250; `ByteSource` re-used from `@enonic-types/core`).
  - Signature verified against `src/main/resources/lib/qrcode.js` (`__.newBean('...QRCodeHandler')` + `.text`/`.size` fields) and `QRCodeHandler.java` (`String text`, `Integer size`, returns `ByteSource`), plus `docs/index.adoc`.
- `types/package.json` — `@enonic-types/lib-qrcode`, `types: index.d.ts`, `publishConfig.access: public`, `dependencies: { "@enonic-types/core": "^8.0.0" }`, `version: "0.0.0"` (substituted at build time).
- `build.gradle` — `assembleTypes` Copy task: `from 'types'` into `build/types/` with `project.version` substituted into `package.json`; `jar.dependsOn assembleTypes`.
- `.github/workflows/enonic-gradle.yml` — `npmPublish: true` on `build-and-publish` and top-level `permissions: { id-token: write, contents: write }` for npm OIDC / trusted publishing.

## Verify

- `./gradlew build` — green locally.
- `build/types/` after build: `index.d.ts` + `package.json` with version substituted (`3.1.0-SNAPSHOT` in the local run).
- `.d.ts` type-checks against `@enonic-types/core@8.0.0`.

## Notes

- First publish of the brand-new `@enonic-types/lib-qrcode` on npm may need trusted-publisher setup.
- Depends on enonic/release-tools#71 (merged).
- Mirrors enonic/lib-mustache#51.

Closes #59