### PR TITLE
Align docs to lib-cors layout #61

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1,4 +1,7 @@
 = QR Code Library
+:toc: right
+
+NOTE: Versions 3.x target XP 8+.
 
 Library for generating QR Code images that can be used from JavaScript controllers in XP apps.
 
@@ -67,7 +70,3 @@ The request function takes a parameter object with options. The `text` option is
 *Returns*
 
 The function will return a `stream` binary object containing a PNG image.
-
-== Compatibility
-
-This library requires Enonic XP release 8.0.0 or higher.

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,6 +1,6 @@
 {
   "versions": [
-    { "label": "2.x", "checkout": "2.x" },
-    { "label": "stable", "checkout": "3.x", "latest": true }
+    { "label": "stable", "checkout": "3.x", "latest": true },
+    { "label": "2.x",    "checkout": "2.x" }
   ]
 }


### PR DESCRIPTION
Closes #61.

Brings `docs/` into line with the reference [lib-cors](https://github.com/enonic/lib-cors) layout, and takes a first sweep at removing any change-log-style clutter.

## Structure conformance

- `docs/index.adoc`: added `NOTE: Versions 3.x target XP 8+.` and `:toc: right` near the top, matching how lib-cors surfaces the target-XP caveat.
- `docs/versions.json`: reordered so `stable` (3.x, latest) precedes `2.x`, matching the order used in lib-cors's `versions.json`.
- `.github/workflows/enonic-docgen.yml`: already triggers on `master`, `3.x`, and `2.x` — no change needed.

## Clutter cleanup

I read every file under `docs/**` looking for the patterns called out in the task:

- inline `(added in vX.Y)` / `(since X.Y)` annotations on options/params
- "Starting from version X …" / "Introduced in X" changelog-style notes
- notes about pre-XP 8 / removed legacy behavior

Nothing of that kind exists in the current docs. `docs/index.adoc` is short and reads as documentation for the current version.

The one thing that arguably counted was the trailing `== Compatibility` section (`This library requires Enonic XP release 8.0.0 or higher.`) — kept as a "genuinely current, useful caveat" per the task, but the same information is now the top-of-doc `NOTE`, and lib-cors's reference layout does not carry a separate Compatibility section. Dropped to avoid duplication; the NOTE preserves the caveat.

## Verify

- `docs/versions.json` is valid JSON (checked with `python3 -c 'import json; json.load(...)'`).
- `.github/workflows/enonic-docgen.yml` is valid YAML.
- No local asciidoctor available in the container; the enonic docgen workflow will render on push.

## Follow-up (separate PR)

The equivalent doc cleanup will be cherry-picked to the `3.x` stable branch. The `2.x` branch is intentionally left alone.