### PR TITLE
Align docs to lib-cors layout (3.x) #61

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1,4 +1,7 @@
 = QR Code Library
+:toc: right
+
+NOTE: Versions 3.x target XP 8+.
 
 Library for generating QR Code images that can be used from JavaScript controllers in XP apps.
 
@@ -67,7 +70,3 @@ The request function takes a parameter object with options. The `text` option is
 *Returns*
 
 The function will return a `stream` binary object containing a PNG image.
-
-== Compatibility
-
-This library requires Enonic XP release 8.0.0 or higher.

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,6 +1,6 @@
 {
   "versions": [
-    { "label": "2.x", "checkout": "2.x" },
-    { "label": "stable", "checkout": "3.x", "latest": true }
+    { "label": "stable", "checkout": "3.x", "latest": true },
+    { "label": "2.x",    "checkout": "2.x" }
   ]
 }


### PR DESCRIPTION
Refs #61. Companion to #62 (master).

Cherry-picks the docs cleanup onto the `3.x` stable branch so the currently-published stable docs match the reference [lib-cors](https://github.com/enonic/lib-cors) layout.

## Changes

- `docs/index.adoc`: `NOTE: Versions 3.x target XP 8+.` + `:toc: right` near the top; dropped the trailing `== Compatibility` section (now redundant with the NOTE, and lib-cors doesn't carry one).
- `docs/versions.json`: `stable`/`3.x` entry precedes `2.x`, matching lib-cors's order.

## Clutter review

Read every file under `docs/**`. No `(added in vX.Y)` / "starting from version X" / pre-XP 8 legacy-behavior notes exist. The docs already read as documentation for the current version.

## Workflow triggers

`.github/workflows/enonic-docgen.yml` on this branch already lists `master`, `3.x`, and `2.x` under `on.push.branches` — no workflow change needed.

## Note

The `2.x` branch is intentionally left untouched.